### PR TITLE
Add posibility to add custom headers

### DIFF
--- a/kontent-delivery/README.md
+++ b/kontent-delivery/README.md
@@ -63,6 +63,7 @@ You can also provide the project ID and other parameters by passing the [`Delive
 - `setProductionEndpoint(String)` - sets the production endpoint address. Mainly useful to change for mocks in unit tests, or if you are establishing a proxy.
 - `setPreviewEndpoint(String)` - sets the preview endpoint address. Mainly useful to change for mocks in unit tests, or if you are establishing a proxy.
 - `setProxyServer(java.net.Proxy)` - sets the proxy server used by the http client. Mainly used to complex Proxy scenarios.
+- `setCustomHeaders(java.utils.List<kentico.kontent.delivery.Header>)` - sets custom headers to be included in the request. *Check the reserved header names in method remarks. These will be ignored.*
 
 The `DeliveryOptions.builder()` can also simplify creating a `DeliveryClient`:
 

--- a/kontent-delivery/src/main/java/kentico/kontent/delivery/DeliveryClient.java
+++ b/kontent-delivery/src/main/java/kentico/kontent/delivery/DeliveryClient.java
@@ -47,7 +47,11 @@ import java.util.stream.Collectors;
 @Slf4j
 public class DeliveryClient {
 
-    private static final String HEADER_X_KC_WAIT_FOR_LOADING_NEW_CONTENT = "X-KC-Wait-For-Loading-New-Content";
+    public static final String HEADER_X_KC_WAIT_FOR_LOADING_NEW_CONTENT = "X-KC-Wait-For-Loading-New-Content";
+    public static final String HEADER_X_KC_SDK_ID = "X-KC-SDKID";
+    public static final String HEADER_AUTHORIZATION = "Authorization";
+    public static final String HEADER_ACCEPT = "Accept";
+    private static final String[] RESERVED_HEADERS = new String[] {HEADER_ACCEPT, HEADER_X_KC_SDK_ID, HEADER_AUTHORIZATION, HEADER_X_KC_WAIT_FOR_LOADING_NEW_CONTENT};
     private static String sdkId;
 
     static {
@@ -578,17 +582,26 @@ public class DeliveryClient {
 
     private Request buildNewRequest(String url) {
         Request.Builder requestBuilder = new Request.Builder().url(url);
-        requestBuilder.header("Accept", "applications/json");
-        requestBuilder.header("X-KC-SDKID", sdkId);
+        requestBuilder.header(HEADER_ACCEPT, "applications/json");
+        requestBuilder.header(HEADER_X_KC_SDK_ID, sdkId);
 
         if (deliveryOptions.getProductionApiKey() != null) {
-            requestBuilder.header("Authorization", String.format("Bearer %s", deliveryOptions.getProductionApiKey()));
+            requestBuilder.header(HEADER_AUTHORIZATION, String.format("Bearer %s", deliveryOptions.getProductionApiKey()));
         } else if (deliveryOptions.isUsePreviewApi()) {
-            requestBuilder.header("Authorization", String.format("Bearer %s", deliveryOptions.getPreviewApiKey()));
+            requestBuilder.header(HEADER_AUTHORIZATION, String.format("Bearer %s", deliveryOptions.getPreviewApiKey()));
         }
         if (deliveryOptions.isWaitForLoadingNewContent()) {
             requestBuilder.header(HEADER_X_KC_WAIT_FOR_LOADING_NEW_CONTENT, "true");
         }
+
+        for (Header header: deliveryOptions.getCustomHeaders()) {
+            if(Arrays.stream(RESERVED_HEADERS).anyMatch(header.getName()::equals)) {
+                log.info("Custom header with name {} will be ignored", header.getName());
+            } else {
+                requestBuilder.header(header.getName(), header.getValue());
+            }
+        }
+
         return requestBuilder.build();
 
     }

--- a/kontent-delivery/src/main/java/kentico/kontent/delivery/DeliveryClient.java
+++ b/kontent-delivery/src/main/java/kentico/kontent/delivery/DeliveryClient.java
@@ -51,7 +51,7 @@ public class DeliveryClient {
     public static final String HEADER_X_KC_SDK_ID = "X-KC-SDKID";
     public static final String HEADER_AUTHORIZATION = "Authorization";
     public static final String HEADER_ACCEPT = "Accept";
-    private static final String[] RESERVED_HEADERS = new String[] {HEADER_ACCEPT, HEADER_X_KC_SDK_ID, HEADER_AUTHORIZATION, HEADER_X_KC_WAIT_FOR_LOADING_NEW_CONTENT};
+    private static final String[] RESERVED_HEADERS = new String[]{HEADER_ACCEPT, HEADER_X_KC_SDK_ID, HEADER_AUTHORIZATION, HEADER_X_KC_WAIT_FOR_LOADING_NEW_CONTENT};
     private static String sdkId;
 
     static {
@@ -364,7 +364,7 @@ public class DeliveryClient {
     /**
      * Not working on Android platform because of JVM and Dalvik differences, please use {@link DeliveryClient#registerType(Class)} instead
      * Register by scanning the classpath for annotated classes by {@link ContentItemMapping} annotation.
-     * 
+     *
      * @param basePackage name of the base package
      */
     @SuppressWarnings("WeakerAccess")
@@ -594,11 +594,13 @@ public class DeliveryClient {
             requestBuilder.header(HEADER_X_KC_WAIT_FOR_LOADING_NEW_CONTENT, "true");
         }
 
-        for (Header header: deliveryOptions.getCustomHeaders()) {
-            if(Arrays.stream(RESERVED_HEADERS).anyMatch(header.getName()::equals)) {
-                log.info("Custom header with name {} will be ignored", header.getName());
-            } else {
-                requestBuilder.header(header.getName(), header.getValue());
+        if (deliveryOptions.getCustomHeaders() != null){
+            for (Header header : deliveryOptions.getCustomHeaders()) {
+                if (Arrays.stream(RESERVED_HEADERS).anyMatch(header.getName()::equals)) {
+                    log.info("Custom header with name {} will be ignored", header.getName());
+                } else {
+                    requestBuilder.header(header.getName(), header.getValue());
+                }
             }
         }
 

--- a/kontent-delivery/src/main/java/kentico/kontent/delivery/DeliveryOptions.java
+++ b/kontent-delivery/src/main/java/kentico/kontent/delivery/DeliveryOptions.java
@@ -27,6 +27,7 @@ package kentico.kontent.delivery;
 import lombok.Builder;
 
 import java.net.Proxy;
+import java.util.List;
 
 /**
  * Keeps settings which are provided by customer or have default values, used in {@link DeliveryClient}.
@@ -157,6 +158,12 @@ public class DeliveryOptions {
      */
     @Builder.Default
     Proxy proxyServer = null;
+
+    /**
+     * Include custom request headers. Headers with name {@link DeliveryClient#HEADER_ACCEPT}, {@link DeliveryClient#HEADER_AUTHORIZATION}, {@link DeliveryClient#HEADER_X_KC_SDK_ID}, {@link DeliveryClient#HEADER_X_KC_WAIT_FOR_LOADING_NEW_CONTENT} will be ignored.
+     */
+    @Builder.Default
+    List<Header> customHeaders = null;
 
     /**
      * Constructs a setting instance of {@link DeliveryOptions} using your Kentico Kontent Project identifier.

--- a/kontent-delivery/src/main/java/kentico/kontent/delivery/Header.java
+++ b/kontent-delivery/src/main/java/kentico/kontent/delivery/Header.java
@@ -1,0 +1,11 @@
+package kentico.kontent.delivery;
+
+@lombok.Data
+@lombok.AllArgsConstructor
+public class Header {
+
+    private String name;
+
+    private String value;
+
+}

--- a/sample-app-android-kotlin/src/main/java/kentico/kontent/delivery/sample/dancinggoat/data/DeliveryClientProvider.kt
+++ b/sample-app-android-kotlin/src/main/java/kentico/kontent/delivery/sample/dancinggoat/data/DeliveryClientProvider.kt
@@ -2,15 +2,30 @@ package kentico.kontent.delivery.sample.dancinggoat.data
 
 import kentico.kontent.delivery.DeliveryClient
 import kentico.kontent.delivery.DeliveryOptions
+import kentico.kontent.delivery.Header
 import kentico.kontent.delivery.sample.dancinggoat.models.Article
+import java.util.*
 
 object DeliveryClientProvider {
+    // https://github.com/Kentico/Home/wiki/Guidelines-for-Kontent-related-tools#analytics
+    private const val TRACKING_HEADER_NAME = "X-KC-SOURCE"
+    private const val TRACKING_HEADER_VALUE = "kentico.kontent.delivery.sample.dancinggoat.android.kotlin;1.0.0"
+
     private var instance: DeliveryClient? = null
 
     val client: DeliveryClient
         get() {
             if (instance == null) {
-                var client = DeliveryClient(DeliveryOptions("975bf280-fd91-488c-994c-2f04416e5ee3"), null)
+                val client = DeliveryClient(
+                        DeliveryOptions
+                                .builder()
+                                .projectId("975bf280-fd91-488c-994c-2f04416e5ee3")
+                                .customHeaders(listOf(
+                                        Header(TRACKING_HEADER_NAME, TRACKING_HEADER_VALUE)
+                                ))
+                                .build(),
+                        null
+                )
                 client.registerType(Article::class.java)
                 instance = client
             }

--- a/sample-app-android/src/main/java/com/github/kentico/delivery_android_sample/data/source/DeliveryClientProvider.java
+++ b/sample-app-android/src/main/java/com/github/kentico/delivery_android_sample/data/source/DeliveryClientProvider.java
@@ -6,13 +6,29 @@ import com.github.kentico.delivery_android_sample.data.models.Cafe;
 import com.github.kentico.delivery_android_sample.data.models.Coffee;
 import kentico.kontent.delivery.DeliveryClient;
 import kentico.kontent.delivery.DeliveryOptions;
+import kentico.kontent.delivery.Header;
+
+import java.util.Arrays;
 
 public class DeliveryClientProvider {
+    // https://github.com/Kentico/Home/wiki/Guidelines-for-Kontent-related-tools#analytics
+    private static final String TRACKING_HEADER_NAME = "X-KC-SOURCE";
+    private static final String TRACKING_HEADER_VALUE = "com.github.kentico.delivery_android_sample;1.0.0";
+
     private static DeliveryClient INSTANCE;
 
     public static DeliveryClient getClient() {
         if (INSTANCE == null) {
-            DeliveryClient client = new DeliveryClient(new DeliveryOptions(AppConfig.KONTENT_PROJECT_ID), null);
+            DeliveryClient client = new DeliveryClient(
+                    DeliveryOptions
+                            .builder()
+                            .projectId(AppConfig.KONTENT_PROJECT_ID)
+                            .customHeaders(Arrays.asList(
+                                    new Header(TRACKING_HEADER_NAME, TRACKING_HEADER_VALUE)
+                            ))
+                            .build(),
+                    null
+            );
             client.registerType(Article.class);
             client.registerType(Cafe.class);
             client.registerType(Coffee.class);

--- a/sample-app-spring-boot/src/main/java/kentico/kontent/delivery/sample/dancinggoat/springboot/KontentConfiguration.java
+++ b/sample-app-spring-boot/src/main/java/kentico/kontent/delivery/sample/dancinggoat/springboot/KontentConfiguration.java
@@ -1,6 +1,8 @@
 package kentico.kontent.delivery.sample.dancinggoat.springboot;
 
 import kentico.kontent.delivery.DeliveryClient;
+import kentico.kontent.delivery.DeliveryOptions;
+import kentico.kontent.delivery.Header;
 import kentico.kontent.delivery.InlineContentItemsResolver;
 import kentico.kontent.delivery.sample.dancinggoat.models.Tweet;
 import org.springframework.boot.json.JsonParserFactory;
@@ -8,13 +10,28 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.Arrays;
 import java.util.Map;
 
 @Configuration
 public class KontentConfiguration {
+
+    // https://github.com/Kentico/Home/wiki/Guidelines-for-Kontent-related-tools#analytics
+    private static final String TRACKING_HEADER_NAME = "X-KC-SOURCE";
+    private static final String TRACKING_HEADER_VALUE = "kentico.kontent.delivery.sample.dancinggoat.java.springboot;1.0.0";
+
     @Bean
     public DeliveryClient deliveryClient() {
-        DeliveryClient client = new DeliveryClient("975bf280-fd91-488c-994c-2f04416e5ee3");
+        DeliveryClient client = new DeliveryClient(
+                DeliveryOptions
+                        .builder()
+                        .projectId("975bf280-fd91-488c-994c-2f04416e5ee3")
+                        .customHeaders(Arrays.asList(
+                                new Header(TRACKING_HEADER_NAME, TRACKING_HEADER_VALUE)
+                        ))
+                        .build()
+        );
+
         client.scanClasspathForMappings("kentico.kontent.delivery.sample.dancinggoat.models");
 
         client.registerInlineContentItemsResolver(new InlineContentItemsResolver<Tweet>() {


### PR DESCRIPTION
### Motivation

Allow users to set custom request headers when using Delivery SDK client.

* Implementation
* Tests
* Used in sample apps to set tracking header

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
