### PR TITLE
add @JsonIgnore to Element.parent

### DIFF
--- a/kontent-delivery/src/main/java/kentico/kontent/delivery/Element.java
+++ b/kontent-delivery/src/main/java/kentico/kontent/delivery/Element.java
@@ -24,6 +24,7 @@
 
 package kentico.kontent.delivery;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -96,6 +97,7 @@ public abstract class Element<T> {
      * @param parent    the parent to this
      * @return          the parent to this
      */
+    @JsonIgnore 
     ContentItem parent;
 
     /**

--- a/kontent-delivery/src/test/java/kentico/kontent/delivery/JacksonBindingsTest.java
+++ b/kontent-delivery/src/test/java/kentico/kontent/delivery/JacksonBindingsTest.java
@@ -146,6 +146,19 @@ public class JacksonBindingsTest {
     }
 
     @Test
+    public void testContentItemSerialization() throws IOException {
+        ContentItemResponse response = objectMapper.readValue(
+                this.getClass().getResource("SampleContentItem.json"), ContentItemResponse.class);
+
+        String serializedContentItemResponse = objectMapper.writeValueAsString(response);
+
+        ContentItemResponse response2 = objectMapper.readValue(
+                serializedContentItemResponse, ContentItemResponse.class);
+
+        Assert.assertEquals(response, response2);
+    }
+
+    @Test
     public void testContentTypeListDeserialization() throws IOException {
         ContentTypesListingResponse response = objectMapper.readValue(
                 this.getClass().getResource("SampleContentTypeList.json"), ContentTypesListingResponse.class);


### PR DESCRIPTION
### Motivation

This makes it possible to serialize ContentItems with Jackson again (it breaks the circular reference chain). It helps with our custom caching solution.

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
