### PR TITLE
Remove condescending language

### DIFF
--- a/kontent-delivery-generators/README.md
+++ b/kontent-delivery-generators/README.md
@@ -11,8 +11,6 @@ This tool generates strongly-typed models based on Content Types in a Kentico Ko
 
 ## Get started
 
-The usage is pretty easy.
-
 1. Create a new instance of Code generator
 
     ```java


### PR DESCRIPTION
Readme for java generator says it's "pretty easy" to use, which I find mildly infuriating. It could be pretty easy if you know your way around Java and used it before, perhaps, but not for a first-timer.