### PR TITLE
Adding missing workflow_step

### DIFF
--- a/kontent-delivery/README.md
+++ b/kontent-delivery/README.md
@@ -317,5 +317,3 @@ We would like to express our thanks to the following people who contributed and 
 - [Jeremy Martin](https://github.com/jerrmartin)
 
 Would you like to become a hero too? Pick an [issue](https://github.com/Kentico/kontent-delivery-sdk-java/issues) and send us a pull request!
-
-![Analytics](https://kentico-ga-beacon.azurewebsites.net/api/UA-69014260-4/Kentico/kontent-java-packages/kontent-delivery?pixel)

--- a/kontent-delivery/README.md
+++ b/kontent-delivery/README.md
@@ -18,21 +18,28 @@ You can use the SDK in the form of a Apache Maven package from [Maven Central](h
 ### Gradle
 
 ```groovy  
-  
-repositories {  
- mavenCentral()}  
-  
-dependencies {  
- implementation 'com.github.kentico:kontent-delivery:latest.release'}  
-```  
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+  implementation 'com.github.kentico:kontent-delivery:latest.release'
+}
+```
 
 > You may want to change `latest.release` to specific one (i.e. `0.0.2-beta.12`).
 
 ### Maven
 
 ```xml  
-<dependency>  
- <groupId>com.github.kentico</groupId> <artifactId>kontent-delivery</artifactId> <version>[0.0.2-beta.12,)</version> <type>pom</type></dependency>  
+<dependency>
+  <groupId>com.github.kentico</groupId>
+  
+  <artifactId>kontent-delivery</artifactId> 
+  <version>[0.0.2-beta.12,)</version> 
+  <type>pom</type>
+</dependency>  
 ```  
 
 > You may want to change version specification - `[0.0.2-beta.12,)` - from [range one](https://cwiki.apache.org/confluence/display/MAVENOLD/Dependency+Mediation+and+Conflict+Resolution#DependencyMediationandConflictResolution-DependencyVersionRanges) to specific one (i.e. `0.0.2-beta.12`).
@@ -64,8 +71,14 @@ You can also provide the project ID and other parameters by passing the [`Delive
 The `DeliveryOptions.builder()` can also simplify creating a `DeliveryClient`:
 
 ```java  
-DeliveryClient client = new DeliveryClient(  
- DeliveryOptions .builder() .projectId("975bf280-fd91-488c-994c-2f04416e5ee3") .productionApiKey("secured key") .build());  
+DeliveryClient client = new DeliveryClient(
+  DeliveryOptions
+  
+    .builder()
+    .projectId("975bf280-fd91-488c-994c-2f04416e5ee3")
+    .productionApiKey("secured key")
+    .build()
+);  
 ```  
 
 Once you create a `DeliveryClient`, you can start querying your project repository by calling methods on the client instance. See [Basic querying](#basic-querying) for details.
@@ -74,11 +87,13 @@ Once you create a `DeliveryClient`, you can start querying your project reposito
 
 To retrieve unpublished content, you need to create a `DeliveryClient` with both Project ID and Preview API key (You could also configure Preview API key in `DeliveryOptions` described above). Each Kontent project has its own Preview API key.
 
-```java  
-// Note: Within a single project, we recommend that you work with only  
-// either the production or preview Delivery API, not both.  
-DeliveryClient client = new DeliveryClient(  
- "YOUR_PROJECT_ID", "YOUR_PREVIEW_API_KEY");  
+```java
+// Note: Within a single project, we recommend that you work with only
+// either the production or preview Delivery API, not both.
+DeliveryClient client = new DeliveryClient(
+  "YOUR_PROJECT_ID",
+  "YOUR_PREVIEW_API_KEY"
+);
 ```  
 
 For more details, see [Previewing unpublished content using the Delivery API](https://docs.kontent.ai/tutorials/write-and-collaborate/preview-content/previewing-unpublished-content).
@@ -103,27 +118,38 @@ Sometimes, it is necessary to transform asynchronous calls `CompletionStage<T>` 
 
 > Keep in mind this transformation needs to handle possible `ExecutionException` and `InterruptedException` that could be raised when waiting to process the transformation.
 
-```java  
-// Retrieves a single content item  
-ContentItemResponse response = client.getItem("about_us")  
- .toCompletableFuture() .get();  
-// Retrieves a list of all content items  
-ContentItemsListingResponse listingResponse = client.getItems()  
- .toCompletableFuture() .get();  
-```  
+```java
+// Retrieves a single content item
+ContentItemResponse response = client.getItem("about_us")
+  .toCompletableFuture()
+  .get();
+
+// Retrieves a list of all content items
+ContentItemsListingResponse listingResponse = client.getItems()
+  .toCompletableFuture()
+  .get();
+```
 
 ### Filtering retrieved data
 
 The SDK supports full scale of the API querying and filtering capabilities as described in the [API reference](https://docs.kontent.ai/reference/delivery-api#tag/Filtering-content).
 
-```java  
-// Retrieves a list of the specified elements from the first 10 content items of  
-// the 'brewer' content type, ordered by the 'product_name' element value  
-// also includes total number of items stored in kentico i.e. for pagination purposes  
-  
-CompletionsStage<ContentItemsListingResponse> response = client.getItems(  
- DeliveryParameterBuilder.params() .language("es-ES") .filterEquals("system.type", "brewer") .projection("image", "price", "product_status", "processing") .page(null, 10) .orderByAsc("elements.product_name") .includeTotalCount() .build())  
-```  
+```java
+// Retrieves a list of the specified elements from the first 10 content items of
+// the 'brewer' content type, ordered by the 'product_name' element value
+// also includes total number of items stored in kentico i.e. for pagination purposes
+
+CompletionsStage<ContentItemsListingResponse> response = client.getItems(
+  DeliveryParameterBuilder.params()
+    .language("es-ES")
+    .filterEquals("system.type", "brewer")
+    .projection("image", "price", "product_status", "processing")
+    .page(null, 10)
+    .orderByAsc("elements.product_name")
+    .includeTotalCount()
+    .build()
+)
+``` 
 
 ## Response structure
 
@@ -214,12 +240,16 @@ getCodename() | The codename of the option. | `dry__natural_
 
 To put the element's options in a list, you can use the following code:
 
-```java  
-List<SelectListItem> items = new List<>();  
-  
-for (Option option : element.getOptions()) {  
- SelectListItem item = new SelectListItem(); item.setText(option.getName()); item.setValue(option.getCodename()); item.setSelected("semi_dry".equals(option.getCodename()));}  
-```  
+```java
+List<SelectListItem> items = new List<>();
+
+for (Option option : element.getOptions()) {
+    SelectListItem item = new SelectListItem();
+    item.setText(option.getName());
+    item.setValue(option.getCodename());
+    item.setSelected("semi_dry".equals(option.getCodename()));
+}
+``` 
 
 ### Linked items
 

--- a/kontent-delivery/README.md
+++ b/kontent-delivery/README.md
@@ -196,7 +196,7 @@ articleItem.getSystem().getCollection()
 // Retrieves codename of the content type of an article content item  
 articleItem.getSystem().getType()  
 
-// Retrieves the Workflow Step of an article content item  
+// Retrieves codename of the workflow step of an article content item
 articleItem.getSystem().getWorkflowStep()  
 ```  
 

--- a/kontent-delivery/README.md
+++ b/kontent-delivery/README.md
@@ -1,11 +1,12 @@
+
 # Kontent Delivery Java SDK
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-[![javadoc](https://javadoc.io/badge2/com.github.kentico/kontent-delivery/javadoc.svg)](https://javadoc.io/doc/com.github.kentico/kontent-delivery)
+[![javadoc](https://javadoc.io/badge2/com.github.kentico/kontent-delivery/javadoc.svg)](https://javadoc.io/doc/com.github.kentico/kontent-delivery)  
 [![Maven Central](https://img.shields.io/maven-central/v/com.github.kentico/kontent-delivery)](https://oss.sonatype.org/content/groups/public/com/github/kentico/kontent-delivery/)
 
-[![GitHub Discussions](https://img.shields.io/badge/GitHub-Discussions-FE7A16.svg?style=popout&logo=github)](https://github.com/Kentico/Home/discussions)
+[![GitHub Discussions](https://img.shields.io/badge/GitHub-Discussions-FE7A16.svg?style=popout&logo=github)](https://github.com/Kentico/Home/discussions)  
 [![Stack Overflow](https://img.shields.io/badge/Stack%20Overflow-ASK%20NOW-FE7A16.svg?logo=stackoverflow&logoColor=white)](https://stackoverflow.com/tags/kentico-kontent)
 
 The Kontent Delivery Java SDK is a client library used for retrieving content from [Kontent by Kentico](https://kontent.ai).
@@ -16,29 +17,23 @@ You can use the SDK in the form of a Apache Maven package from [Maven Central](h
 
 ### Gradle
 
-```groovy
-
-repositories {
-    mavenCentral()
-}
-
-dependencies {
-  implementation 'com.github.kentico:kontent-delivery:latest.release'
-}
-```
+```groovy  
+  
+repositories {  
+ mavenCentral()}  
+  
+dependencies {  
+ implementation 'com.github.kentico:kontent-delivery:latest.release'}  
+```  
 
 > You may want to change `latest.release` to specific one (i.e. `0.0.2-beta.12`).
 
 ### Maven
 
-```xml
-<dependency>
-  <groupId>com.github.kentico</groupId>
-  <artifactId>kontent-delivery</artifactId>
-  <version>[0.0.2-beta.12,)</version>
-  <type>pom</type>
-</dependency>
-```
+```xml  
+<dependency>  
+ <groupId>com.github.kentico</groupId> <artifactId>kontent-delivery</artifactId> <version>[0.0.2-beta.12,)</version> <type>pom</type></dependency>  
+```  
 
 > You may want to change version specification - `[0.0.2-beta.12,)` - from [range one](https://cwiki.apache.org/confluence/display/MAVENOLD/Dependency+Mediation+and+Conflict+Resolution#DependencyMediationandConflictResolution-DependencyVersionRanges) to specific one (i.e. `0.0.2-beta.12`).
 
@@ -48,10 +43,10 @@ The `DeliveryClient` class is the main class of the SDK. Using this class, you c
 
 To create an instance of the class, you need to provide a [project ID](https://docs.kontent.ai/tutorials/develop-apps/get-content/getting-content#a-getting-content-items).
 
-```java
-// Initializes an instance of the DeliveryClient client
-DeliveryClient client = new DeliveryClient("975bf280-fd91-488c-994c-2f04416e5ee3");
-```
+```java  
+// Initializes an instance of the DeliveryClient client  
+DeliveryClient client = new DeliveryClient("975bf280-fd91-488c-994c-2f04416e5ee3");  
+```  
 
 You can also provide the project ID and other parameters by passing the [`DeliveryOptions`](./src/main/java/kentico/kontent/delivery/DeliveryOptions.java) object to the class constructor. The `DeliveryOptions` object can be used to set the following parameters:
 
@@ -68,15 +63,10 @@ You can also provide the project ID and other parameters by passing the [`Delive
 
 The `DeliveryOptions.builder()` can also simplify creating a `DeliveryClient`:
 
-```java
-DeliveryClient client = new DeliveryClient(
-  DeliveryOptions
-    .builder()
-    .projectId("975bf280-fd91-488c-994c-2f04416e5ee3")
-    .productionApiKey("secured key")
-    .build()
-);
-```
+```java  
+DeliveryClient client = new DeliveryClient(  
+ DeliveryOptions .builder() .projectId("975bf280-fd91-488c-994c-2f04416e5ee3") .productionApiKey("secured key") .build());  
+```  
 
 Once you create a `DeliveryClient`, you can start querying your project repository by calling methods on the client instance. See [Basic querying](#basic-querying) for details.
 
@@ -84,14 +74,12 @@ Once you create a `DeliveryClient`, you can start querying your project reposito
 
 To retrieve unpublished content, you need to create a `DeliveryClient` with both Project ID and Preview API key (You could also configure Preview API key in `DeliveryOptions` described above). Each Kontent project has its own Preview API key.
 
-```java
-// Note: Within a single project, we recommend that you work with only
-// either the production or preview Delivery API, not both.
-DeliveryClient client = new DeliveryClient(
-  "YOUR_PROJECT_ID",
-  "YOUR_PREVIEW_API_KEY"
-);
-```
+```java  
+// Note: Within a single project, we recommend that you work with only  
+// either the production or preview Delivery API, not both.  
+DeliveryClient client = new DeliveryClient(  
+ "YOUR_PROJECT_ID", "YOUR_PREVIEW_API_KEY");  
+```  
 
 For more details, see [Previewing unpublished content using the Delivery API](https://docs.kontent.ai/tutorials/write-and-collaborate/preview-content/previewing-unpublished-content).
 
@@ -99,13 +87,13 @@ For more details, see [Previewing unpublished content using the Delivery API](ht
 
 Once you have a `DeliveryClient` instance, you can start querying your project repository by calling methods on the instance.
 
-```java
-// Retrieves a single content item
-CompletionStage<ContentItemResponse> response = client.getItem("about_us");
-
-// Retrieves a list of all content items
-CompletionStage<ContentItemsListingResponse> listingResponse = client.getItems();
-```
+```java  
+// Retrieves a single content item  
+CompletionStage<ContentItemResponse> response = client.getItem("about_us");  
+  
+// Retrieves a list of all content items  
+CompletionStage<ContentItemsListingResponse> listingResponse = client.getItems();  
+```  
 
 As you may have noticed from the example `DeliveryClient` is returning [`CompletionStage<T>`](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html) that allows you to chain the requests, perform filtering, data transformation, etc.
 
@@ -115,38 +103,27 @@ Sometimes, it is necessary to transform asynchronous calls `CompletionStage<T>` 
 
 > Keep in mind this transformation needs to handle possible `ExecutionException` and `InterruptedException` that could be raised when waiting to process the transformation.
 
-```java
-// Retrieves a single content item
-ContentItemResponse response = client.getItem("about_us")
-  .toCompletableFuture()
-  .get();
-
-// Retrieves a list of all content items
-ContentItemsListingResponse listingResponse = client.getItems()
-  .toCompletableFuture()
-  .get();
-```
+```java  
+// Retrieves a single content item  
+ContentItemResponse response = client.getItem("about_us")  
+ .toCompletableFuture() .get();  
+// Retrieves a list of all content items  
+ContentItemsListingResponse listingResponse = client.getItems()  
+ .toCompletableFuture() .get();  
+```  
 
 ### Filtering retrieved data
 
 The SDK supports full scale of the API querying and filtering capabilities as described in the [API reference](https://docs.kontent.ai/reference/delivery-api#tag/Filtering-content).
 
-```java
-// Retrieves a list of the specified elements from the first 10 content items of
-// the 'brewer' content type, ordered by the 'product_name' element value
-// also includes total number of items stored in kentico i.e. for pagination purposes
-
-CompletionsStage<ContentItemsListingResponse> response = client.getItems(
-  DeliveryParameterBuilder.params()
-    .language("es-ES")
-    .filterEquals("system.type", "brewer")
-    .projection("image", "price", "product_status", "processing")
-    .page(null, 10)
-    .orderByAsc("elements.product_name")
-    .includeTotalCount()
-    .build()
-)
-```
+```java  
+// Retrieves a list of the specified elements from the first 10 content items of  
+// the 'brewer' content type, ordered by the 'product_name' element value  
+// also includes total number of items stored in kentico i.e. for pagination purposes  
+  
+CompletionsStage<ContentItemsListingResponse> response = client.getItems(  
+ DeliveryParameterBuilder.params() .language("es-ES") .filterEquals("system.type", "brewer") .projection("image", "price", "product_status", "processing") .page(null, 10) .orderByAsc("elements.product_name") .includeTotalCount() .build())  
+```  
 
 ## Response structure
 
@@ -172,7 +149,7 @@ When retrieving a list of content items, you get an instance of the `ContentItem
 
 The `ContentItem` class provides the following:
 
-- `getSystem()` returns a `System` object with metadata such as code name, display name, type, collection, or sitemap location.
+- `getSystem()` returns a `System` object with metadata such as code name, display name, type, collection, sitemap location, or workflow step.
 - `getElements()` returns a Map containing all the elements included in the response keyed by code names.
 - Methods for easier access to certain types of content elements such as linked items, or assets.
 
@@ -180,19 +157,22 @@ The `ContentItem` class provides the following:
 
 You can access information about a content item (i.e., its ID, codename, name, location in sitemap, date of last modification, its collection codename, and its content type codename) by using the `System` object.
 
-```java
-// Retrieves name of an article content item
-articleItem.getSystem().getName()
+```java  
+// Retrieves name of an article content item  
+articleItem.getSystem().getName()  
+  
+// Retrieves codename of an article content item  
+articleItem.getSystem().getCodename()  
+  
+// Retrieves codename of the collection of an article content item  
+articleItem.getSystem().getCollection()  
+  
+// Retrieves codename of the content type of an article content item  
+articleItem.getSystem().getType()  
 
-// Retrieves codename of an article content item
-articleItem.getSystem().getCodename()
-
-// Retrieves codename of the collection of an article content item
-articleItem.getSystem().getCollection()
-
-// Retrieves codename of the content type of an article content item
-articleItem.getSystem().getType()
-```
+// Retrieves the Workflow Step of an article content item  
+articleItem.getSystem().getWorkflowStep()  
+```  
 
 ## Getting element values
 
@@ -202,69 +182,65 @@ The SDK provides methods for retrieving content from content elements such as As
 
 For text elements, you can use the `getString` method.
 
-```java
-// Retrieves an article text from the 'body_copy' Text element
-articleItem.getString("body_copy")
-```
+```java  
+// Retrieves an article text from the 'body_copy' Text element  
+articleItem.getString("body_copy")  
+```  
 
 The Rich text element can contain links to other content items within your project. See [Resolving links to content items](https://github.com/Kentico/kontent-delivery-sdk-java/wiki/Resolving-links-to-content-items) for more details.
 
 ### Asset
 
-```java
-// Retrieves a teaser image URL
-articleItem.getAssets("teaser_image").get(0).getUrl()
-```
+```java  
+// Retrieves a teaser image URL  
+articleItem.getAssets("teaser_image").get(0).getUrl()  
+```  
 
 ### Multiple choice
 
 To get a list of options defined in a Multiple choice content element, you first need to retrieve the content element itself. For this purpose, you can use the `getContentTypeElement` method, which takes the codename of a content type and the codename of a content element.
 
-```java
-// Retrieves the 'processing' element of the 'coffee' content type
-MultipleChoiceElement element = (MultipleChoiceElement) client.getContentTypeElement("coffee", "processing");
-```
+```java  
+// Retrieves the 'processing' element of the 'coffee' content type  
+MultipleChoiceElement element = (MultipleChoiceElement) client.getContentTypeElement("coffee", "processing");  
+```  
 
 After you retrieve the Multiple choice element, you can work with its list of options. Each option has the following methods:
 
 Method | Description | Example
----------|----------|---------
- getName() | The display name of the option. | `Dry (Natural)`
- getCodename() | The codename of the option. | `dry__natural_
+---------|----------|---------  
+getName() | The display name of the option. | `Dry (Natural)`
+getCodename() | The codename of the option. | `dry__natural_
 
- To put the element's options in a list, you can use the following code:
+To put the element's options in a list, you can use the following code:
 
-```java
-List<SelectListItem> items = new List<>();
-
-for (Option option : element.getOptions()) {
-    SelectListItem item = new SelectListItem();
-    item.setText(option.getName());
-    item.setValue(option.getCodename());
-    item.setSelected("semi_dry".equals(option.getCodename()));
-}
-```
+```java  
+List<SelectListItem> items = new List<>();  
+  
+for (Option option : element.getOptions()) {  
+ SelectListItem item = new SelectListItem(); item.setText(option.getName()); item.setValue(option.getCodename()); item.setSelected("semi_dry".equals(option.getCodename()));}  
+```  
 
 ### Linked items
 
-```java
-// Retrieves related articles
-articleItem.getLinkedItems("related_articles")
-```
+```java  
+// Retrieves related articles  
+articleItem.getLinkedItems("related_articles")  
+```  
 
 ### Custom items
 
-```java
-// Retrieves the value of the custom element 'color'
-String customElementValue = ((CustomElement) articleItem.getElements().get("color")).getValue();
-```
+```java  
+// Retrieves the value of the custom element 'color'  
+String customElementValue = ((CustomElement) articleItem.getElements().get("color")).getValue();  
+```  
 
 ## Android development
 
- To use this SDK for [Android](https://developer.android.com/) development, you can use any approach compatible with [Java CompletionStage API](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html). Most common is to use [Kotlin coroutines](https://kotlinlang.org/docs/reference/coroutines-overview.html) for Android applications written in Kotlin and [Java RX](https://github.com/ReactiveX/RxJava) for Android applications written in Java. Both of these approaches are showcased in this repository:
- 
- * [Android Java sample application](../sample-app-android#readme)
- * [Android Kotlin Java Sample application](../sample-app-android-kotlin#readme)
+To use this SDK for [Android](https://developer.android.com/) development, you can use any approach compatible with [Java CompletionStage API](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html). Most common is to use [Kotlin coroutines](https://kotlinlang.org/docs/reference/coroutines-overview.html) for Android applications written in Kotlin and [Java RX](https://github.com/ReactiveX/RxJava) for Android applications written in Java. Both of these approaches are showcased in this repository:
+
+* [Android Java sample application](../sample-app-android#readme)
+* [Android Kotlin Java Sample application](../sample-app-android-kotlin#readme)
 
 ⚠ There are two Android-specific rules you need to follow in order for the Delivery SDK to work correctly.
 
@@ -275,9 +251,9 @@ String customElementValue = ((CustomElement) articleItem.getElements().get("colo
 
 You need to instantiate the Delivery client with the constructor that disables the template engine. The template engine is meant to be used with the web platform only. For Android development, use the constructor `DeliveryClient#DeliveryClient(DeliveryOptions, TemplateEngineConfig)` and set the second parameter to `null`.
 
-```java
-DeliveryClient client = new DeliveryClient(new DeliveryOptions(AppConfig.KONTENT_PROJECT_ID), null);
-```
+```java  
+DeliveryClient client = new DeliveryClient(new DeliveryOptions(AppConfig.KONTENT_PROJECT_ID), null);  
+```  
 
 See it [used in a sample app](../sample-app-android/src/main/java/com/github/kentico/delivery_android_sample/data/source/DeliveryClientProvider.java)).
 
@@ -308,6 +284,7 @@ We would like to express our thanks to the following people who contributed and 
 - [Adam J. Weigold](https://github.com/aweigold)
 - [Tommaso Garuglieri](https://github.com/GaruGaru)
 - [Gabriel Cunha](https://github.com/cunhazera)
+- [Jeremy Martin](https://github.com/jerrmartin)
 
 Would you like to become a hero too? Pick an [issue](https://github.com/Kentico/kontent-delivery-sdk-java/issues) and send us a pull request!
 

--- a/kontent-delivery/src/main/java/kentico/kontent/delivery/System.java
+++ b/kontent-delivery/src/main/java/kentico/kontent/delivery/System.java
@@ -116,4 +116,12 @@ public class System {
     @JsonProperty("last_modified")
     ZonedDateTime lastModified;
 
+    /**
+     * The codename of the item's current workflow step.
+     *
+     * @param workflowStep  Sets the workflowStep of this.
+     * @return              The workflow step of this.
+     */
+    @JsonProperty("workflow_step")
+    String workflowStep;
 }

--- a/kontent-delivery/src/test/java/kentico/kontent/delivery/DeliveryClientTest.java
+++ b/kontent-delivery/src/test/java/kentico/kontent/delivery/DeliveryClientTest.java
@@ -832,9 +832,9 @@ public class DeliveryClientTest extends LocalServerTestBase {
         Assert.assertNotNull(item.getArticleItems());
         Assert.assertEquals(2, item.getArticleItems().size());
         Assert.assertNotNull(item.getAllLinkedItems());
-        Assert.assertEquals(2, item.getAllLinkedItems().size());
+        Assert.assertEquals(3, item.getAllLinkedItems().size());
         Assert.assertNotNull(item.getAllLinkedItemsMap());
-        Assert.assertEquals(2, item.getAllLinkedItemsMap().size());
+        Assert.assertEquals(3, item.getAllLinkedItemsMap().size());
     }
 
     @Test

--- a/kontent-delivery/src/test/java/kentico/kontent/delivery/JacksonBindingsTest.java
+++ b/kontent-delivery/src/test/java/kentico/kontent/delivery/JacksonBindingsTest.java
@@ -96,7 +96,7 @@ public class JacksonBindingsTest {
         Assert.assertEquals(response, response3);
         Assert.assertEquals(response.hashCode(), response3.hashCode());
 
-        Assert.assertEquals(2, response.getLinkedItems().size());
+        Assert.assertEquals(3, response.getLinkedItems().size());
 
         ContentItem contentItem = response.getItem();
         Assert.assertNotNull(contentItem);
@@ -118,8 +118,9 @@ public class JacksonBindingsTest {
         Assert.assertEquals(2016, system.getLastModified().getYear());
         Assert.assertEquals(1, system.getSitemapLocations().size());
         Assert.assertEquals("articles", system.getSitemapLocations().get(0));
+        Assert.assertEquals("published", system.getWorkflowStep());
 
-        Assert.assertEquals(6, contentItem.elements.size());
+        Assert.assertEquals(7, contentItem.elements.size());
         Element title = contentItem.elements.get("title");
         Assert.assertNotNull(title);
         Assert.assertNotNull(title.toString());
@@ -136,14 +137,19 @@ public class JacksonBindingsTest {
         Assert.assertEquals(0, contentItem.getAssets("post_date").size());
 
         Assert.assertNotNull(contentItem.getLinkedItem("coffee_processing_techniques"));
+        Assert.assertNotNull(contentItem.getLinkedItem("origins_of_arabica_bourbon"));
+        Assert.assertNotNull(contentItem.getLinkedItem("component_child"));
         Assert.assertNull(contentItem.getLinkedItem("non_existent"));
+
+        // Testing that Component does not have a `workflow_step`
+        Assert.assertNotNull(contentItem.getLinkedItem("component_child").getSystem());
+        Assert.assertNull(contentItem.getLinkedItem("component_child").getSystem().getWorkflowStep());
 
         Element themeColor = contentItem.elements.get("theme_color");
         Assert.assertNotNull(themeColor);
         Assert.assertNotNull(themeColor.toString());
         Assert.assertEquals("custom", themeColor.getType());
         Assert.assertEquals("#ff0000", themeColor.getValue());
-
     }
 
     @Test
@@ -211,6 +217,7 @@ public class JacksonBindingsTest {
         Assert.assertNull(system.getCollection());
         Assert.assertNull(system.getType());
         Assert.assertNull(system.getSitemapLocations());
+        Assert.assertNull(system.getWorkflowStep());
 
         Assert.assertEquals(11, contentType.getElements().size());
         Element element = contentType.getElements().get("processing");

--- a/kontent-delivery/src/test/resources/kentico/kontent/delivery/DocsExamplesListContentItems.json
+++ b/kontent-delivery/src/test/resources/kentico/kontent/delivery/DocsExamplesListContentItems.json
@@ -10,7 +10,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-06-27T13:01:54.5735581Z"
+        "last_modified": "2017-06-27T13:01:54.5735581Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "personas": {
@@ -95,7 +96,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-04-04T13:40:14.6418507Z"
+        "last_modified": "2017-04-04T13:40:14.6418507Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "personas": {
@@ -195,7 +197,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-04-04T13:40:29.970377Z"
+        "last_modified": "2017-04-04T13:40:29.970377Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "personas": {
@@ -277,7 +280,8 @@
         "language": "en-US",
         "type": "tweet",
         "sitemap_locations": [],
-        "last_modified": "2017-06-27T13:00:08.2735049Z"
+        "last_modified": "2017-06-27T13:00:08.2735049Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "tweet_link": {
@@ -317,7 +321,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-04-04T13:45:30.7692802Z"
+        "last_modified": "2017-04-04T13:45:30.7692802Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "personas": {
@@ -406,7 +411,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-06-27T13:11:28.3348114Z"
+        "last_modified": "2017-06-27T13:11:28.3348114Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "personas": {
@@ -499,7 +505,8 @@
         "language": "en-US",
         "type": "hosted_video",
         "sitemap_locations": [],
-        "last_modified": "2017-06-27T12:57:16.7333276Z"
+        "last_modified": "2017-06-27T12:57:16.7333276Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "video_id": {

--- a/kontent-delivery/src/test/resources/kentico/kontent/delivery/DocsExamplesRetrievingContentInSpecificLanguage.json
+++ b/kontent-delivery/src/test/resources/kentico/kontent/delivery/DocsExamplesRetrievingContentInSpecificLanguage.json
@@ -9,7 +9,8 @@
       "sitemap_locations": [
         "articles"
       ],
-      "last_modified": "2017-07-20T12:18:13.2848024Z"
+      "last_modified": "2017-07-20T12:18:13.2848024Z",
+      "workflow_step": "published"
     },
     "elements": {
       "personas": {
@@ -98,7 +99,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-07-20T12:24:13.379713Z"
+        "last_modified": "2017-07-20T12:24:13.379713Z",
+        "workflow_step": "published"
       },
       "elements": {
         "personas": {

--- a/kontent-delivery/src/test/resources/kentico/kontent/delivery/SampleContentItem.json
+++ b/kontent-delivery/src/test/resources/kentico/kontent/delivery/SampleContentItem.json
@@ -54,6 +54,16 @@
         "type": "custom",
         "name": "Theme color",
         "value": "#ff0000"
+      },
+      "coffee_component": {
+        "type": "rich_text",
+        "name": "Coffee Component",
+        "images": {},
+        "links": {},
+        "modular_content": [
+          "component_child"
+        ],
+        "value": "<object type=\"application/kenticocloud\" data-type=\"item\" data-rel=\"component\" data-codename=\"component_child\"></object>"
       }
     }
   },
@@ -68,7 +78,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-04-04T13:40:14.6418507Z"
+        "last_modified": "2017-04-04T13:40:14.6418507Z",
+        "workflow_step": "published"
       },
       "elements": {
         "personas": {
@@ -168,7 +179,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-04-04T13:45:44.1533096Z"
+        "last_modified": "2017-04-04T13:45:44.1533096Z",
+        "workflow_step": "published"
       },
       "elements": {
         "personas": {
@@ -241,6 +253,33 @@
           "type": "url_slug",
           "name": "URL pattern",
           "value": "origins-of-arabica-bourbon"
+        }
+      }
+    },
+    "component_child": {
+      "system": {
+        "id": "da49061f-66d7-5cfe-62d1-fe109f9f6e46",
+        "name": "da49061f-66d7-5cfe-62d1-fe109f9f6e46",
+        "codename": "component_child",
+        "language": "default",
+        "type": "component",
+        "collection": "default",
+        "sitemap_locations": [],
+        "last_modified": "2022-06-15T17:30:08.8489088Z"
+      },
+      "elements": {
+        "text": {
+          "type": "rich_text",
+          "name": "Text",
+          "images": {},
+          "links": {},
+          "modular_content": [],
+          "value": "<p>I should not have a \"workflow_step\" included in my \"system\".</p>"
+        },
+        "title": {
+          "type": "text",
+          "name": "Title",
+          "value": "I am a Component"
         }
       }
     }

--- a/kontent-delivery/src/test/resources/kentico/kontent/delivery/SampleContentItem.json
+++ b/kontent-delivery/src/test/resources/kentico/kontent/delivery/SampleContentItem.json
@@ -10,7 +10,8 @@
       "sitemap_locations": [
         "articles"
       ],
-      "last_modified": "2016-10-20T12:03:48.4628352Z"
+      "last_modified": "2016-10-20T12:03:48.4628352Z",
+      "workflow_step": "published"
     },
     "elements": {
       "title": {

--- a/kontent-delivery/src/test/resources/kentico/kontent/delivery/SampleContentItemList.json
+++ b/kontent-delivery/src/test/resources/kentico/kontent/delivery/SampleContentItemList.json
@@ -11,7 +11,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-04-04T13:40:00.1102334Z"
+        "last_modified": "2017-04-04T13:40:00.1102334Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "title": {
@@ -55,7 +56,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-04-04T13:40:29.970377Z"
+        "last_modified": "2017-04-04T13:40:29.970377Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "title": {
@@ -121,7 +123,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-04-04T13:45:44.1533096Z"
+        "last_modified": "2017-04-04T13:45:44.1533096Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "title": {
@@ -167,7 +170,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-04-04T13:40:14.6418507Z"
+        "last_modified": "2017-04-04T13:40:14.6418507Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "personas": {
@@ -268,7 +272,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-04-04T13:45:44.1533096Z"
+        "last_modified": "2017-04-04T13:45:44.1533096Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "personas": {

--- a/kontent-delivery/src/test/resources/kentico/kontent/delivery/SampleContentItemListWithLinkedItems.json
+++ b/kontent-delivery/src/test/resources/kentico/kontent/delivery/SampleContentItemListWithLinkedItems.json
@@ -9,7 +9,8 @@
         "type": "hosted_video",
         "collection": "default",
         "sitemap_locations": [],
-        "last_modified": "2017-06-27T12:56:41.1882715Z"
+        "last_modified": "2017-06-27T12:56:41.1882715Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "video_id": {
@@ -1398,7 +1399,8 @@
           "cafes",
           "north_america"
         ],
-        "last_modified": "2016-09-05T14:14:00.6640656Z"
+        "last_modified": "2016-09-05T14:14:00.6640656Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "street": {
@@ -1463,7 +1465,8 @@
           "cafes",
           "europe"
         ],
-        "last_modified": "2016-09-01T08:36:18.0623079Z"
+        "last_modified": "2016-09-01T08:36:18.0623079Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "street": {
@@ -1528,7 +1531,8 @@
           "cafes",
           "north_america"
         ],
-        "last_modified": "2016-09-05T14:14:08.4285085Z"
+        "last_modified": "2016-09-05T14:14:08.4285085Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "street": {
@@ -1592,7 +1596,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-04-04T13:45:30.7692802Z"
+        "last_modified": "2017-04-04T13:45:30.7692802Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "personas": {
@@ -1682,7 +1687,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-04-04T13:45:44.1533096Z"
+        "last_modified": "2017-04-04T13:45:44.1533096Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "personas": {
@@ -1769,7 +1775,8 @@
         "sitemap_locations": [
           "about_us"
         ],
-        "last_modified": "2016-10-20T12:06:18.3403458Z"
+        "last_modified": "2016-10-20T12:06:18.3403458Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "title": {
@@ -1811,7 +1818,8 @@
         "sitemap_locations": [
           "about_us"
         ],
-        "last_modified": "2017-04-04T11:49:14.9737715Z"
+        "last_modified": "2017-04-04T11:49:14.9737715Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "title": {
@@ -1859,7 +1867,8 @@
         "sitemap_locations": [
           "accessories"
         ],
-        "last_modified": "2017-04-04T13:39:15.0306576Z"
+        "last_modified": "2017-04-04T13:39:15.0306576Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "product_name": {
@@ -1930,7 +1939,8 @@
         "sitemap_locations": [
           "grinders"
         ],
-        "last_modified": "2017-04-04T13:52:33.3284917Z"
+        "last_modified": "2017-04-04T13:52:33.3284917Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "product_name": {
@@ -2001,7 +2011,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-06-27T13:11:28.3348114Z"
+        "last_modified": "2017-06-27T13:11:28.3348114Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "personas": {
@@ -2100,7 +2111,8 @@
           "cafes",
           "north_america"
         ],
-        "last_modified": "2016-09-05T14:14:08.4285085Z"
+        "last_modified": "2016-09-05T14:14:08.4285085Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "street": {
@@ -2165,7 +2177,8 @@
           "cafes",
           "north_america"
         ],
-        "last_modified": "2016-09-05T14:12:49.0914134Z"
+        "last_modified": "2016-09-05T14:12:49.0914134Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "street": {
@@ -2227,7 +2240,8 @@
         "type": "hero_unit",
         "collection": "default",
         "sitemap_locations": [],
-        "last_modified": "2017-03-22T12:40:16.8440029Z"
+        "last_modified": "2017-03-22T12:40:16.8440029Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "title": {
@@ -2269,7 +2283,8 @@
         "sitemap_locations": [
           "about_us"
         ],
-        "last_modified": "2017-04-04T11:49:14.9737715Z"
+        "last_modified": "2017-04-04T11:49:14.9737715Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "title": {
@@ -2317,7 +2332,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-04-04T13:45:44.1533096Z"
+        "last_modified": "2017-04-04T13:45:44.1533096Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "personas": {
@@ -2404,7 +2420,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-06-27T13:11:28.3348114Z"
+        "last_modified": "2017-06-27T13:11:28.3348114Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "personas": {
@@ -2500,7 +2517,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-04-04T13:45:30.7692802Z"
+        "last_modified": "2017-04-04T13:45:30.7692802Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "personas": {
@@ -2590,7 +2608,8 @@
         "sitemap_locations": [
           "about_us"
         ],
-        "last_modified": "2016-10-20T12:47:13.65023Z"
+        "last_modified": "2016-10-20T12:47:13.65023Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "title": {
@@ -2633,7 +2652,8 @@
           "cafes",
           "north_america"
         ],
-        "last_modified": "2016-09-05T14:13:52.934532Z"
+        "last_modified": "2016-09-05T14:13:52.934532Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "street": {
@@ -2698,7 +2718,8 @@
           "cafes",
           "north_america"
         ],
-        "last_modified": "2016-09-05T14:14:00.6640656Z"
+        "last_modified": "2016-09-05T14:14:00.6640656Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "street": {
@@ -2762,7 +2783,8 @@
         "sitemap_locations": [
           "about_us"
         ],
-        "last_modified": "2017-04-04T11:48:26.1878079Z"
+        "last_modified": "2017-04-04T11:48:26.1878079Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "title": {
@@ -2810,7 +2832,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-06-27T13:01:54.5735581Z"
+        "last_modified": "2017-06-27T13:01:54.5735581Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "personas": {
@@ -2896,7 +2919,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-04-04T13:40:29.970377Z"
+        "last_modified": "2017-04-04T13:40:29.970377Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "personas": {
@@ -2979,7 +3003,8 @@
         "sitemap_locations": [
           "articles"
         ],
-        "last_modified": "2017-04-04T13:40:14.6418507Z"
+        "last_modified": "2017-04-04T13:40:14.6418507Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "personas": {
@@ -3080,7 +3105,8 @@
         "sitemap_locations": [
           "home"
         ],
-        "last_modified": "2016-10-20T12:15:15.7357761Z"
+        "last_modified": "2016-10-20T12:15:15.7357761Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "title": {
@@ -3122,7 +3148,8 @@
         "sitemap_locations": [
           "about_us"
         ],
-        "last_modified": "2016-10-20T12:06:18.3403458Z"
+        "last_modified": "2016-10-20T12:06:18.3403458Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "title": {
@@ -3162,7 +3189,8 @@
         "type": "tweet",
         "collection": "default",
         "sitemap_locations": [],
-        "last_modified": "2017-06-27T13:00:08.2735049Z"
+        "last_modified": "2017-06-27T13:00:08.2735049Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "tweet_link": {
@@ -3201,7 +3229,8 @@
         "type": "hosted_video",
         "collection": "default",
         "sitemap_locations": [],
-        "last_modified": "2017-06-27T12:56:41.1882715Z"
+        "last_modified": "2017-06-27T12:56:41.1882715Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "video_id": {
@@ -3230,7 +3259,8 @@
         "type": "hosted_video",
         "collection": "default",
         "sitemap_locations": [],
-        "last_modified": "2017-06-27T12:57:16.7333276Z"
+        "last_modified": "2017-06-27T12:57:16.7333276Z",
+        "workflow_step": "draft"
       },
       "elements": {
         "video_id": {

--- a/kontent-delivery/src/test/resources/kentico/kontent/delivery/SampleContentTypeList.json
+++ b/kontent-delivery/src/test/resources/kentico/kontent/delivery/SampleContentTypeList.json
@@ -5,7 +5,8 @@
         "id": "b7aa4a53-d9b1-48cf-b7a6-ed0b182c4b89",
         "name": "Article",
         "codename": "article",
-        "last_modified": "2017-04-04T13:40:29.970377Z"
+        "last_modified": "2017-04-04T13:40:29.970377Z",
+        "workflow_step": "published"
       },
       "elements": {
         "personas": {
@@ -52,7 +53,8 @@
         "id": "7bc932b3-ce2a-4aa7-954e-04cbcbd214fc",
         "name": "Brewer",
         "codename": "brewer",
-        "last_modified": "2017-04-04T13:40:29.970377Z"
+        "last_modified": "2017-04-04T13:40:29.970377Z",
+        "workflow_step": "published"
       },
       "elements": {
         "product_name": {

--- a/kontent-delivery/src/test/resources/kentico/kontent/delivery/SampleKontentItemWithComplexEmptyValueRichText.json
+++ b/kontent-delivery/src/test/resources/kentico/kontent/delivery/SampleKontentItemWithComplexEmptyValueRichText.json
@@ -8,7 +8,8 @@
       "type": "fake_type_1",
       "collection": "default",
       "sitemap_locations": [],
-      "last_modified": "2018-01-01T00:00:00.0000000Z"
+      "last_modified": "2018-01-01T00:00:00.0000000Z",
+      "workflow_step": "published"
     },
     "elements": {
       "empty_value": {

--- a/kontent-delivery/src/test/resources/kentico/kontent/delivery/SampleKontentItemWithComplexTablesRichText.json
+++ b/kontent-delivery/src/test/resources/kentico/kontent/delivery/SampleKontentItemWithComplexTablesRichText.json
@@ -8,7 +8,8 @@
       "type": "simple_rich_text",
       "collection": "default",
       "sitemap_locations": [],
-      "last_modified": "2020-03-16T17:49:42.7165723Z"
+      "last_modified": "2020-03-16T17:49:42.7165723Z",
+      "workflow_step": "published"
     },
     "elements": {
       "rich_text": {

--- a/kontent-delivery/src/test/resources/kentico/kontent/delivery/SampleTaxonomyGroup.json
+++ b/kontent-delivery/src/test/resources/kentico/kontent/delivery/SampleTaxonomyGroup.json
@@ -3,7 +3,8 @@
     "id": "f30c7f72-e9ab-8832-2a57-62944a038809",
     "name": "Personas",
     "codename": "personas",
-    "last_modified": "2016-10-20T13:24:00.3200182Z"
+    "last_modified": "2016-10-20T13:24:00.3200182Z",
+    "workflow_step": "published"
   },
   "terms": [
     {

--- a/kontent-delivery/src/test/resources/kentico/kontent/delivery/SampleTaxonomyGroupListingResponse.json
+++ b/kontent-delivery/src/test/resources/kentico/kontent/delivery/SampleTaxonomyGroupListingResponse.json
@@ -5,7 +5,8 @@
         "id": "f30c7f72-e9ab-8832-2a57-62944a038809",
         "name": "Personas",
         "codename": "personas",
-        "last_modified": "2016-10-20T13:24:00.3200182Z"
+        "last_modified": "2016-10-20T13:24:00.3200182Z",
+        "workflow_step": "draft"
       },
       "terms": [
         {
@@ -47,7 +48,8 @@
         "id": "d351400e-0290-87b2-1413-6c411d8ae5a4",
         "name": "Processing type",
         "codename": "processing_type",
-        "last_modified": "2017-09-04T12:50:20.7857817Z"
+        "last_modified": "2017-09-04T12:50:20.7857817Z",
+        "workflow_step": "published"
       },
       "terms": [
         {
@@ -72,7 +74,8 @@
         "id": "79b1c5b6-30bc-d076-a236-d9ec9f1ff01b",
         "name": "Product status",
         "codename": "product_status",
-        "last_modified": "2016-09-15T10:53:25.2233101Z"
+        "last_modified": "2016-09-15T10:53:25.2233101Z",
+        "workflow_step": "published"
       },
       "terms": [
         {


### PR DESCRIPTION
### Motivation

Which issue does this fix? N/A

If no issue exists, what is the fix or new feature? Were there any reasons to fix/implement things that are not obvious?
- adding in `workflow_step` field as part of `System` class
    - Documentation [here](https://kontent.ai/learn/reference/delivery-api/#tag/Linked-content-and-components) lists `workflow_step` in the response, but Java SDK has no field to access this data on an initialized System Object. 
### Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [X] Tests are passing
- [ ] Docs have been updated (if applicable)
- [X] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?

#### Step 1:
> Tip: lines 11 and (28-42) can be commented out.

In the Main.java file, edit the `DeliveryOptions` on line 13 to target a test Kontent Project and to look like this:
```
DeliveryOptions options = DeliveryOptions.builder()
                .projectId("<YOUR-PROJECT-ID>")
                .retryAttempts(2)
                .waitForLoadingNewContent(true)
                .previewApiKey("<YOUR-PREVIEW-API-KEY>")
                .usePreviewApi(true)
                .build();
```

#### Step 2:
Rename `client` to `client2` on line 23, then remove the `.getName()` from line 25, and reference an item in the test Kontent Project like so: 
```
        client2.getItem("<KONTENT-ITEM-CODENAME>")
                .thenAccept(item ->
                        System.out.println(item.getItem().getSystem()));
```

#### Expected Results: 
When targeting a test project with an unpublished element you should see a System object printed out displaying the `workflow_step` as one of the fields like so: 
```
System(id=<SOME-ID>, name=<SOME-NAME>, codename=<SOME-CODENAME>, language=default, type=<SOME-TYPE>, collection=default, sitemapLocations=[], lastModified=<SOME-TIMESTAMP>, workflowStep=draft)

```